### PR TITLE
Fixing link for Ogg Vorbis

### DIFF
--- a/data/links.xml
+++ b/data/links.xml
@@ -15,7 +15,7 @@
 		</link>
 		<link>
 			<name>Ogg Vorbis</name>
-			<url>https://www.xiph.org/ogg/vorbis/</url>
+			<url>https://www.xiph.org/vorbis/</url>
 			<description>Ogg Vorbis is a fully open, non-proprietary, patent-and-royalty-free, general-purpose compressed audio format. ResidualVM optionally supports playback of CD tracks and other audio data encoded using Ogg Vorbis.</description>
 		</link>
 		<link>


### PR DESCRIPTION
The URL has changed, so I'm pointing to the new link.

Corresponds to [scummvm-web #115](https://github.com/scummvm/scummvm-web/pull/115).