### PR TITLE
Converting XML files to UTF-8

### DIFF
--- a/data/compatibility/compat-0.1.0.xml
+++ b/data/compatibility/compat-0.1.0.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <compatibility xmlns:h="http://www.w3.org/TR/xhtml1/">
 	<company>
 		<name>LucasArts</name>

--- a/data/compatibility/compat-0.1.1.xml
+++ b/data/compatibility/compat-0.1.1.xml
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <compatibility xmlns:h="http://www.w3.org/TR/xhtml1/">
 	<company>
 		<name>LucasArts</name>
 		<games>
 			<game>
-				<name>Grim Fandango</name>
+				<name>Grim Fandango</name>h
 				<target>grim</target>
 				<percent>85</percent>
 				<notes>

--- a/data/compatibility/compat-0.2.0.xml
+++ b/data/compatibility/compat-0.2.0.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <compatibility xmlns:h="http://www.w3.org/TR/xhtml1/">
 	<company>
 		<name>LucasArts</name>

--- a/data/compatibility/compat-0.2.1.xml
+++ b/data/compatibility/compat-0.2.1.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <compatibility xmlns:h="http://www.w3.org/TR/xhtml1/">
 	<company>
 		<name>LucasArts</name>

--- a/data/compatibility/compat-0.3.0.xml
+++ b/data/compatibility/compat-0.3.0.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <compatibility xmlns:h="http://www.w3.org/TR/xhtml1/">
 	<company>
 		<name>LucasArts</name>

--- a/data/compatibility/compat-0.3.1.xml
+++ b/data/compatibility/compat-0.3.1.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <compatibility xmlns:h="http://www.w3.org/TR/xhtml1/">
 	<company>
 		<name>LucasArts</name>

--- a/data/compatibility/compat-DEV.xml
+++ b/data/compatibility/compat-DEV.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <compatibility xmlns:h="http://www.w3.org/TR/xhtml1/">
 	<company>
 		<name>LucasArts</name>

--- a/data/documentation.xml
+++ b/data/documentation.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <documentation xmlns:h="http://www.w3.org/TR/html4/">
 	<document>
 		<name>README</name>

--- a/data/downloads.xml
+++ b/data/downloads.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="iso-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <downloads xmlns:h="http://www.w3.org/TR/html4/">
 	<section>
 		<title>

--- a/data/faq-xml.xml
+++ b/data/faq-xml.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="iso-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <faq xmlns:h="http://www.w3.org/TR/html4/">
   <section>
     <title>Introduction</title>

--- a/data/game_demos.xml
+++ b/data/game_demos.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <game_demos>
 	<group>
 		<name>LucasArts Demos</name>

--- a/data/links.xml
+++ b/data/links.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <external_links xmlns:h="http://www.w3.org/TR/html4/">
 	<group>
 		<name>Libraries &amp; Technologies</name>

--- a/data/menus.xml
+++ b/data/menus.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <menus>
 	<group>
 		<name>Main Menu</name>

--- a/data/screenshots.xml
+++ b/data/screenshots.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- <file> contains the base of the filename, thumbnail is <file>.jpg, full image is <file>-full.png -->
 <screenshots>
 	<group>


### PR DESCRIPTION
Corresponds with[ scummvm-web #113](https://github.com/scummvm/scummvm-web/pull/113) and [#118](https://github.com/scummvm/scummvm-web/pull/118). This will avoid issues should pages try to include characters like `é`.